### PR TITLE
Improve logging and error handling on adb push

### DIFF
--- a/src/adb.js
+++ b/src/adb.js
@@ -201,15 +201,22 @@ class Adb {
           "push",
           guardedfile,
           dest,
-          process.platform == "win32" ? "> nul" : "> /dev/null"
+          process.platform == "win32" ? "> nul" : ' | grep -v "%]"'
         ])
-        .then(stdout => {
+        .then(() => {
           clearInterval(progressInterval);
           resolve();
         })
         .catch(e => {
           clearInterval(progressInterval);
-          reject("Push failed: " + e);
+          _this
+            .hasAccess()
+            .then(access => {
+              reject(access ? "Push failed: " + e : "connection lost");
+            })
+            .catch(() => {
+              reject("Push failed: " + e);
+            });
         });
     });
   }


### PR DESCRIPTION
We might be able to use findstr on windows, but i'm not 100% sure how that works, so for now this should help us a little with getting more useful errors. Grep confirmed working on linux and macos.