### PR TITLE
Oem unlock not necessary

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "promise-android-tools",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "promise-android-tools",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "description": "A wrapper for adb and fastboot that returns convenient promises.",
   "main": "./src/module.js",
   "scripts": {

--- a/src/fastboot.js
+++ b/src/fastboot.js
@@ -159,7 +159,8 @@ class Fastboot {
       .catch(error => {
         if (
           error &&
-          error.message.includes("FAILED (remote: Already Unlocked)")
+          (error.message.includes("FAILED (remote: Already Unlocked)") ||
+            error.message.includes("FAILED (remote: 'Not necessary')"))
         )
           return;
         else throw new Error("oem unlock failed: " + error);

--- a/tests/unit-tests/test_fastboot.js
+++ b/tests/unit-tests/test_fastboot.js
@@ -355,6 +355,21 @@ describe("Fastboot module", function() {
           expect(execFake).to.have.been.calledWith(["oem", "unlock"]);
         });
       });
+      it("should resolve if not necessary", function() {
+        const execFake = sinon.fake((args, callback) => {
+          callback(
+            true,
+            "",
+            "FAILED (remote: 'Not necessary')\nfastboot: error: Command failed"
+          );
+        });
+        const logSpy = sinon.spy();
+        const fastboot = new Fastboot({ exec: execFake, log: logSpy });
+        return fastboot.oemUnlock().then(r => {
+          expect(execFake).to.have.been.called;
+          expect(execFake).to.have.been.calledWith(["oem", "unlock"]);
+        });
+      });
       it("should reject if unlocking failed", function() {
         const execFake = sinon.fake((args, callback) => {
           callback(true, "everything exploded");


### PR DESCRIPTION
As always, every device throws their own fucking errors incompatible with the rest. This adds a new exception. Fixes https://github.com/ubports/ubports-installer/issues/1327.