### PR TITLE
Catch another fastboot oem lock error

### DIFF
--- a/src/common.js
+++ b/src/common.js
@@ -60,6 +60,9 @@ function handleError(error, stdout, stderr) {
       stderr.includes("FAILED (remote: 'not allowed in locked state')") ||
       stderr.includes(
         "FAILED (remote: 'Device not unlocked cannot flash or erase')"
+      ) ||
+      stderr.includes(
+        "FAILED (remote: '\tDevice not unlocked cannot flash or erase')"
       ))
   ) {
     return "bootloader is locked";

--- a/src/common.js
+++ b/src/common.js
@@ -55,6 +55,7 @@ function handleError(error, stdout, stderr) {
   } else if (
     stderr &&
     (stderr.includes("FAILED (remote: not supported in locked device)") ||
+      stderr.includes("FAILED (remote: ‘not supported in locked device’)") ||
       stderr.includes("FAILED (remote: 'Bootloader is locked.')") ||
       stderr.includes("FAILED (remote: 'not allowed in locked state')") ||
       stderr.includes(

--- a/tests/unit-tests/test_common.js
+++ b/tests/unit-tests/test_common.js
@@ -62,6 +62,12 @@ const recognizedErrors = [
     expectedReturn: "bootloader is locked",
     error: { killed: false, code: 1, signal: null, cmd: "command" },
     stdout: undefined,
+    stderr: "FAILED (remote: ‘not supported in locked device’)"
+  },
+  {
+    expectedReturn: "bootloader is locked",
+    error: { killed: false, code: 1, signal: null, cmd: "command" },
+    stdout: undefined,
     stderr: "FAILED (remote: 'not allowed in locked state')"
   },
   {

--- a/tests/unit-tests/test_common.js
+++ b/tests/unit-tests/test_common.js
@@ -77,6 +77,12 @@ const recognizedErrors = [
     stderr: "FAILED (remote: 'Device not unlocked cannot flash or erase')"
   },
   {
+    expectedReturn: "bootloader is locked",
+    error: { killed: false, code: 1, signal: null, cmd: "command" },
+    stdout: undefined,
+    stderr: "FAILED (remote: '\tDevice not unlocked cannot flash or erase')"
+  },
+  {
     expectedReturn: "low battery",
     error: { killed: false, code: 1, signal: null, cmd: "command" },
     stdout: undefined,


### PR DESCRIPTION
as seen here: https://github.com/ubports/ubports-installer/issues/1468
while we could also check for the stuff within the quotes, but i prefer to keep it consistent and check for every thing by itself as we get it from the devices.