### PR TITLE
New unlock features

### DIFF
--- a/src/fastboot.js
+++ b/src/fastboot.js
@@ -304,14 +304,11 @@ export class Fastboot extends Tool {
    */
   oemUnlock() {
     return this.exec("oem", "unlock")
-      .then(() => {
-        return;
-      })
+      .then(() => null)
       .catch(error => {
         if (
-          error &&
-          (error.message.includes("FAILED (remote: Already Unlocked)") ||
-            error.message.includes("FAILED (remote: 'Not necessary')"))
+          error?.message.includes("Already Unlocked") ||
+          error?.message.includes("Not necessary")
         )
           return;
         else throw new Error("oem unlock failed: " + error);
@@ -324,12 +321,52 @@ export class Fastboot extends Tool {
    */
   oemLock() {
     return this.exec("oem", "lock")
-      .then(() => {
-        return;
-      })
+      .then(() => null)
       .catch(error => {
         throw new Error("oem lock failed: " + error);
       });
+  }
+
+  /**
+   * lock partitions for flashing
+   * @returns {Promise}
+   */
+  flashingLock() {
+    return this.exec("flashing", "lock").then(() => null);
+  }
+
+  /**
+   * unlock partitions for flashing
+   * @returns {Promise}
+   */
+  flashingUnlock() {
+    return this.exec("flashing", "unlock").then(() => null);
+  }
+
+  /**
+   * lock 'critical' bootloader partitions
+   * @returns {Promise}
+   */
+  flashingLockCritical() {
+    return this.exec("flashing", "lock_critical").then(() => null);
+  }
+
+  /**
+   * unlock 'critical' bootloader partitions
+   * @returns {Promise}
+   */
+  flashingUnlockCritical() {
+    return this.exec("flashing", "unlock_critical").then(() => null);
+  }
+
+  /**
+   * Find out if a device can be flashing-unlocked
+   * @returns {Promise<Boolean>}
+   */
+  getUnlockAbility() {
+    return this.exec("flashing", "get_unlock_ability")
+      .then(stdout => stdout?.trim() === "1")
+      .catch(() => false);
   }
 
   /**

--- a/src/fastboot.js
+++ b/src/fastboot.js
@@ -300,10 +300,11 @@ export class Fastboot extends Tool {
 
   /**
    * Lift OEM lock
+   * @param {String} [code] optional unlock code (including 0x if necessary)
    * @returns {Promise}
    */
-  oemUnlock() {
-    return this.exec("oem", "unlock")
+  oemUnlock(code = "") {
+    return this.exec(...["oem", "unlock", code || []].flat())
       .then(() => null)
       .catch(error => {
         if (

--- a/tests/unit-tests/test_fastboot.js
+++ b/tests/unit-tests/test_fastboot.js
@@ -404,6 +404,47 @@ describe("Fastboot module", function() {
         );
       });
     });
+    [
+      { f: "flashingLock", args: ["flashing", "lock"] },
+      { f: "flashingUnlock", args: ["flashing", "unlock"] },
+      { f: "flashingLockCritical", args: ["flashing", "lock_critical"] },
+      { f: "flashingUnlockCritical", args: ["flashing", "unlock_critical"] }
+    ].forEach(f => {
+      it(`should run ${f.args}`, function() {
+        stubExec();
+        const fastboot = new Fastboot();
+        return fastboot[f.f]().then(r => {
+          expect(r).to.eql(null);
+          expectArgs(...f.args);
+        });
+      });
+    });
+    describe("getUnlockAbility()", function() {
+      it("should resolve true if unlockable", function() {
+        stubExec(null, "1");
+        const fastboot = new Fastboot();
+        return fastboot.getUnlockAbility().then(r => {
+          expect(r).to.eql(true);
+          expectArgs("flashing", "get_unlock_ability");
+        });
+      });
+      it("should resolve false if not unlockable", function() {
+        stubExec(null, "0");
+        const fastboot = new Fastboot();
+        return fastboot.getUnlockAbility().then(r => {
+          expect(r).to.eql(false);
+          expectArgs("flashing", "get_unlock_ability");
+        });
+      });
+      it("should resolve false on error", function() {
+        stubExec(true, "everything exploded");
+        const fastboot = new Fastboot();
+        return fastboot.getUnlockAbility().then(r => {
+          expect(r).to.eql(false);
+          expectArgs("flashing", "get_unlock_ability");
+        });
+      });
+    });
     describe("setActive()", function() {
       it("should resolve after setting active slot", function() {
         stubExec();

--- a/tests/unit-tests/test_fastboot.js
+++ b/tests/unit-tests/test_fastboot.js
@@ -362,6 +362,13 @@ describe("Fastboot module", function() {
           expectArgs("oem", "unlock");
         });
       });
+      it("should use code if specified", function() {
+        stubExec();
+        const fastboot = new Fastboot();
+        return fastboot.oemUnlock("0x0123456789ABCDEF").then(r => {
+          expectArgs("oem", "unlock", "0x0123456789ABCDEF");
+        });
+      });
       it("should resolve if already unlocked", function() {
         stubExec(true, "FAILED (remote: Already Unlocked)");
         const fastboot = new Fastboot();

--- a/tests/unit-tests/test_fastboot.js
+++ b/tests/unit-tests/test_fastboot.js
@@ -410,12 +410,23 @@ describe("Fastboot module", function() {
       { f: "flashingLockCritical", args: ["flashing", "lock_critical"] },
       { f: "flashingUnlockCritical", args: ["flashing", "unlock_critical"] }
     ].forEach(f => {
-      it(`should run ${f.args}`, function() {
-        stubExec();
-        const fastboot = new Fastboot();
-        return fastboot[f.f]().then(r => {
-          expect(r).to.eql(null);
-          expectArgs(...f.args);
+      describe(`${f.f}()`, function() {
+        it(`should resolve after ${f.args.join(" ")}`, function() {
+          stubExec();
+          const fastboot = new Fastboot();
+          return fastboot[f.f]().then(r => {
+            expect(r).to.eql(null);
+            expectArgs(...f.args);
+          });
+        });
+        it(`should reject if ${f.args.join(" ")} failed`, function(done) {
+          stubExec(true);
+          const fastboot = new Fastboot();
+          fastboot[f.f]().catch(r => {
+            expect(r.message).to.eql('{"error":true}');
+            expectArgs(...f.args);
+            done();
+          });
         });
       });
     });


### PR DESCRIPTION
This adds the `fastboot flashing unlock` method used by the latest devices, as well as the oem unlock key [required by sony devices](https://developer.sony.com/develop/open-devices/get-started/unlock-bootloader/how-to-unlock-bootloader/#bootloader_guide). Prerequisites for https://github.com/ubports/ubports-installer/issues/1479.