### PR TITLE
Fix race conditions in starting adb

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,8 +30,8 @@ jobs:
             ${{ runner.os }}-build-
             ${{ runner.os }}-
 
-      - name: npm install
-        run: npm install
+      - name: npm ci
+        run: npm ci
       - name: npm audit
         run: npm audit --production
       - name: npm run build
@@ -70,14 +70,14 @@ jobs:
 
       - name: test-nocover
         run: |
-          npm install
+          npm ci
           npm run test-nocover
 
       # only generate coverage on linux
       - name: test
         if: contains(runner.os, 'Linux')
         run: |
-          npm install
+          npm ci
           npm run test
 
       - name: codecov.io

--- a/src/adb.js
+++ b/src/adb.js
@@ -82,9 +82,7 @@ export class Adb extends Tool {
    * @returns {Promise}
    */
   startServer() {
-    return this.killServer().then(() => {
-      this.exec("start-server");
-    });
+    return this.killServer().then(() => this.exec("start-server"));
   }
 
   /**


### PR DESCRIPTION
Since we don't return the start-server exec promise, clients would run more adb commands before the server was up. This would cause "Connection Refused" to be returned to the second adb command, and everyone was confused.

Actually returning the exec allows downstreams to wait on the server starting.

Ref: https://github.com/ubports/ubports-installer/issues/1847