### PR TITLE
Fastboot: add command to wipe super

### DIFF
--- a/src/fastboot.js
+++ b/src/fastboot.js
@@ -297,6 +297,21 @@ export class Fastboot extends Tool {
       });
   }
 
+  /**
+   * Wipe the super partition and reset the partition layout
+   * @param {String} image - super image containing the new partition layout
+   * @returns {Promise}
+   */
+  wipeSuper(image) {
+    return this.exec("wipe-super", image)
+      .then(() => {
+        return;
+      })
+      .catch(error => {
+        throw new Error("wiping super failed: " + error);
+      });
+  }
+
   //////////////////////////////////////////////////////////////////////////////
   // Convenience functions
   //////////////////////////////////////////////////////////////////////////////

--- a/src/fastboot.spec.js
+++ b/src/fastboot.spec.js
@@ -533,6 +533,26 @@ describe("Fastboot module", function () {
       });
     });
   });
+  describe("wipeSuper()", function () {
+    it("should resolve after wiping super", function () {
+      stubExec();
+      const fastboot = new Fastboot();
+      return fastboot.wipeSuper("/path/to/image").then(r => {
+        expectArgs("wipe-super", "/path/to/image");
+      });
+    });
+    it("should reject if wiping super failed", function (done) {
+      stubExec(true, "everything exploded");
+      const fastboot = new Fastboot();
+      fastboot.wipeSuper("/path/to/image").catch(error => {
+        expectReject(
+          error,
+          'wiping super failed: Error: {"error":true,"stdout":"everything exploded"}'
+        );
+        done();
+      });
+    });
+  });
   describe("convenience functions", function () {
     describe("hasAccess()", function () {
       it("should resolve true when a device is detected", function () {


### PR DESCRIPTION
This allows devices with super partition to wipe the
super partition and repartition it with a new layout
provided in the image.

Example to generate a new super partition layout:

> lpmake \
    --metadata-size 65536 --metadata-slots 2 \
    --super-name super --device super:12884901888 \
    --group mainline:12876513280 \
    --partition system_a:none:6442450944:mainline \
    --partition vendor_a:none:3221225472:mainline \
    --partition product_a:none:1073741824:mainline \
    --output super_mainline.img

Above command will result in:

> lpdump super_mainline.img

```
lpdump E 03-10 13:36:12 259537 259537 reader.cpp:121] [liblp]bool android::fs_mgr::ReadPrimaryGeometry(int, LpMetadataGeometry *) read 4096 bytes failed: Success
lpdump E 03-10 13:36:12 259537 259537 reader.cpp:134] [liblp]bool android::fs_mgr::ReadBackupGeometry(int, LpMetadataGeometry *) backup read 4096 bytes failed: Success
Metadata version: 10.0
Metadata size: 516 bytes
Metadata max size: 65536 bytes
Metadata slot count: 2
Partition table:
------------------------
  Name: system_a
  Group: mainline
  Attributes: none
  Extents:
    0 .. 12582911 linear super 2048
------------------------
  Name: vendor_a
  Group: mainline
  Attributes: none
  Extents:
    0 .. 6291455 linear super 12584960
------------------------
  Name: product_a
  Group: mainline
  Attributes: none
  Extents:
    0 .. 2097151 linear super 18876416
------------------------
Block device table:
------------------------
  Partition name: super
  First sector: 2048
  Size: 12884901888 bytes
  Flags: none
------------------------
Group table:
------------------------
  Name: default
  Maximum size: 0 bytes
  Flags: none
------------------------
  Name: mainline
  Maximum size: 12876513280 bytes
  Flags: none
------------------------
```