### PR TITLE
Fastboot: improve compatibility of reboot commands

### DIFF
--- a/src/fastboot.js
+++ b/src/fastboot.js
@@ -215,7 +215,7 @@ export class Fastboot extends Tool {
    * @returns {Promise}
    */
   rebootFastboot() {
-    return this.exec("reboot fastboot")
+    return this.exec("reboot-fastboot")
       .then(() => {
         return;
       })
@@ -229,7 +229,7 @@ export class Fastboot extends Tool {
    * @returns {Promise}
    */
   rebootRecovery() {
-    return this.exec("reboot recovery")
+    return this.exec("reboot-recovery")
       .then(() => {
         return;
       })

--- a/src/fastboot.spec.js
+++ b/src/fastboot.spec.js
@@ -275,7 +275,7 @@ describe("Fastboot module", function () {
         stubExec();
         const fastboot = new Fastboot();
         return fastboot.rebootFastboot().then(r => {
-          expectArgs("reboot fastboot");
+          expectArgs("reboot-fastboot");
         });
       });
       it("should reject if rebooting fails", function (done) {
@@ -295,7 +295,7 @@ describe("Fastboot module", function () {
         stubExec();
         const fastboot = new Fastboot();
         return fastboot.rebootRecovery().then(r => {
-          expectArgs("reboot recovery");
+          expectArgs("reboot-recovery");
         });
       });
       it("should reject if rebooting fails", function (done) {


### PR DESCRIPTION
Use `reboot-fastboot` and `reboot-recovery` like the already
previously implemented `reboot-bootloader`.
