### PR TITLE
Fastboot: add commands for interacting with logical partitions

### DIFF
--- a/src/fastboot.js
+++ b/src/fastboot.js
@@ -327,6 +327,53 @@ export class Fastboot extends Tool {
   }
 
   /**
+   * Create a logical partition with the given name and size, in the super partition.
+   * @param {String} partition - name of partition
+   * @param {String} size - size in bytes
+   * @returns {Promise}
+   */
+  createLogicalPartition(partition, size) {
+    return this.exec("create-logical-partition", partition, size)
+      .then(() => {
+        return;
+      })
+      .catch(error => {
+        throw new Error("creating logical partition failed: " + error);
+      });
+  }
+
+  /**
+   * Delete a logical partition with the given name.
+   * @param {String} partition - name of partition
+   * @returns {Promise}
+   */
+  deleteLogicalPartition(partition) {
+    return this.exec("delete-logical-partition", partition)
+      .then(() => {
+        return;
+      })
+      .catch(error => {
+        throw new Error("deleting logical partition failed: " + error);
+      });
+  }
+
+  /**
+   * Resize a logical partition with the given name and final size, in the super partition.
+   * @param {String} partition - name of partition
+   * @param {String} size - size in bytes
+   * @returns {Promise}
+   */
+  resizeLogicalPartition(partition, size) {
+    return this.exec("resize-logical-partition", partition, size)
+      .then(() => {
+        return;
+      })
+      .catch(error => {
+        throw new Error("resizing logical partition failed: " + error);
+      });
+  }
+
+  /**
    * Wipe the super partition and reset the partition layout
    * @param {String} image - super image containing the new partition layout
    * @returns {Promise}

--- a/src/fastboot.spec.js
+++ b/src/fastboot.spec.js
@@ -573,6 +573,74 @@ describe("Fastboot module", function () {
       });
     });
   });
+  describe("createLogicalPartition()", function () {
+    it("should resolve after creating logical partition", function () {
+      stubExec();
+      const fastboot = new Fastboot();
+      return fastboot
+        .createLogicalPartition("partition_name", 3221225472)
+        .then(r => {
+          expectArgs("create-logical-partition", "partition_name", 3221225472);
+        });
+    });
+    it("should reject if creating logical partition failed", function (done) {
+      stubExec(true, "everything exploded");
+      const fastboot = new Fastboot();
+      fastboot
+        .createLogicalPartition("partition_name", 3221225472)
+        .catch(error => {
+          expectReject(
+            error,
+            'creating logical partition failed: Error: {"error":true,"stdout":"everything exploded"}'
+          );
+          done();
+        });
+    });
+  });
+  describe("deleteLogicalPartition()", function () {
+    it("should resolve after deleting logical partition", function () {
+      stubExec();
+      const fastboot = new Fastboot();
+      return fastboot.deleteLogicalPartition("partition_name").then(r => {
+        expectArgs("delete-logical-partition", "partition_name");
+      });
+    });
+    it("should reject if deleting logical partition failed", function (done) {
+      stubExec(true, "everything exploded");
+      const fastboot = new Fastboot();
+      fastboot.deleteLogicalPartition("partition_name").catch(error => {
+        expectReject(
+          error,
+          'deleting logical partition failed: Error: {"error":true,"stdout":"everything exploded"}'
+        );
+        done();
+      });
+    });
+  });
+  describe("resizeLogicalPartition()", function () {
+    it("should resolve after resizing logical partition", function () {
+      stubExec();
+      const fastboot = new Fastboot();
+      return fastboot
+        .resizeLogicalPartition("partition_name", 3221225472)
+        .then(r => {
+          expectArgs("resize-logical-partition", "partition_name", 3221225472);
+        });
+    });
+    it("should reject if resizing logical partition failed", function (done) {
+      stubExec(true, "everything exploded");
+      const fastboot = new Fastboot();
+      fastboot
+        .resizeLogicalPartition("partition_name", 3221225472)
+        .catch(error => {
+          expectReject(
+            error,
+            'resizing logical partition failed: Error: {"error":true,"stdout":"everything exploded"}'
+          );
+          done();
+        });
+    });
+  });
   describe("wipeSuper()", function () {
     it("should resolve after wiping super", function () {
       stubExec();


### PR DESCRIPTION
This adds support for the following fastboot commands:
  - create-logical-partition
  - delete-logical-partition
  - resize-logical-partition