### PR TITLE
Fix CRLF handling in fastboot getvar

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "promise-android-tools",
-  "version": "4.0.10",
+  "version": "4.0.11",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "promise-android-tools",
-      "version": "4.0.10",
+      "version": "4.0.11",
       "license": "GPL-3.0",
       "dependencies": {
         "android-tools-bin": "^1.0.6",

--- a/src/fastboot.js
+++ b/src/fastboot.js
@@ -491,23 +491,22 @@ export class Fastboot extends Tool {
    * @param {String} variable variable to get
    * @returns {Promise<String>} codename
    */
-  getvar(variable) {
-    return this.hasAccess()
-      .then(access => {
-        if (access) {
-          return this.exec("getvar", variable);
-        } else {
-          throw new Error("no device");
-        }
-      })
-      .then(r => r.split("\n")[0].split(": "))
-      .then(([name, value]) => {
-        if (name !== variable) {
-          throw new Error(`Unexpected getvar return: ${name}`);
-        } else {
-          return value;
-        }
-      });
+  async getvar(variable) {
+    if (!await this.hasAccess()) {
+      throw new Error("no device");
+    }
+
+    const result = await this.exec("getvar", variable);
+    const [ name, value ] = result
+      .replace(/\r\n/g, '\n')
+      .split("\n")[0]
+      .split(": ");
+
+    if (name !== variable) {
+      throw new Error(`Unexpected getvar return: ${name}`);
+    }
+
+    return value;
   }
 
   /**

--- a/src/fastboot.spec.js
+++ b/src/fastboot.spec.js
@@ -727,6 +727,15 @@ describe("Fastboot module", function () {
           done();
         });
       });
+      it("should handle CRLF", function () {
+        stubExec(null, null, "product: FP2\r\nFinished. Total time: 0.000s");
+        const fastboot = new Fastboot();
+        fastboot.hasAccess = jest.fn().mockResolvedValue(true);
+        return fastboot.getvar("product").then(r => {
+          expect(r).toEqual("FP2");
+          expectArgs("getvar", "product");
+        });
+      });
     });
     describe("getDeviceName()", function () {
       it("should resolve bootloader var", function () {


### PR DESCRIPTION
Also updated package-lock in a separate commit, so please don't squash - https://github.com/ubports/promise-android-tools/commit/fe3232d207cc2bcbb890a5abe4b45db024f07b9e left 4.0.10 in the lockfile.