### PR TITLE
Introduce a setPath option for tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ promise-android-tools versioning started at 1.0.0, but this changelog was not ad
 
 ## [Unreleased]
 
+### Added
+
+- Introduce a setPath option for tools ([#72](https://github.com/ubports/promise-android-tools/pull/72))
+
 ## [4.0.13] - 2022-09-07
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "promise-android-tools",
-  "version": "4.0.13",
+  "version": "4.0.14",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "promise-android-tools",
-      "version": "4.0.13",
+      "version": "4.0.14",
       "license": "GPL-3.0",
       "dependencies": {
         "android-tools-bin": "^1.0.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "promise-android-tools",
-  "version": "4.0.13",
+  "version": "4.0.14",
   "description": "A wrapper for adb, fastboot, and heimdall that returns convenient promises.",
   "main": "./lib/module.cjs",
   "type": "module",

--- a/src/adb.js
+++ b/src/adb.js
@@ -1,7 +1,8 @@
 "use strict";
 
 /*
- * Copyright (C) 2017-2020 UBports Foundation <info@ubports.com>
+ * Copyright (C) 2017-2022 UBports Foundation <info@ubports.com>
+ * Copyright (C) 2017-2022 Johannah Sprinz <info@ubports.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/adb.spec.js
+++ b/src/adb.spec.js
@@ -354,7 +354,7 @@ describe("Adb module", function () {
           expect(child_process.spawn).toHaveBeenCalledWith(
             adb.executable,
             [...adb.extra, "sideload", "tests/test-data/test_file"],
-            { env: { ADB_TRACE: "rwx" } }
+            { env: expect.objectContaining({ ADB_TRACE: "rwx" }) }
           );
         });
       });
@@ -1018,6 +1018,7 @@ describe("Adb module", function () {
     it("should restore full backup", function () {
       stubExec(1, "should not be called");
       jest.useFakeTimers();
+      jest.setSystemTime();
       fs.readJSON = jest.fn().mockReturnValue({
         codename: "codename",
         comment: "Ubuntu Touch backup created on 1970-01-01T00:00:00.000Z",

--- a/src/adb.spec.js
+++ b/src/adb.spec.js
@@ -1,7 +1,8 @@
 "use strict";
 
 /*
- * Copyright (C) 2017-2021 UBports Foundation <info@ubports.com>
+ * Copyright (C) 2017-2022 UBports Foundation <info@ubports.com>
+ * Copyright (C) 2017-2022 Johannah Sprinz <hannah@ubports.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/cancelable-promise.js
+++ b/src/cancelable-promise.js
@@ -1,7 +1,8 @@
 "use strict";
 
 /*
- * Copyright (C) 2020 UBports Foundation <info@ubports.com>
+ * Copyright (C) 2020-2022 UBports Foundation <info@ubports.com>
+ * Copyright (C) 2020-2022 Johannah Sprinz <hannah@ubports.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/cancelable-promise.spec.js
+++ b/src/cancelable-promise.spec.js
@@ -1,0 +1,37 @@
+"use strict";
+
+/*
+ * Copyright (C) 2022 UBports Foundation <info@ubports.com>
+ * Copyright (C) 2022 Johannah Sprinz <hannah@ubports.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { jest, expect } from "@jest/globals";
+
+import cp from "cancelable-promise";
+
+describe("CancelablePromise", function () {
+  it("should export tool when packaged", function () {
+    cp.CancelablePromise = null;
+    return import("./cancelable-promise.js").then(cp =>
+      expect(cp).toBeTruthy()
+    );
+  });
+  it("should export tool when native", function () {
+    return import("./cancelable-promise.js").then(cp =>
+      expect(cp).toBeTruthy()
+    );
+  });
+});

--- a/src/common.js
+++ b/src/common.js
@@ -1,7 +1,8 @@
 "use strict";
 
 /*
- * Copyright (C) 2017-2020 UBports Foundation <info@ubports.com>
+ * Copyright (C) 2017-2022 UBports Foundation <info@ubports.com>
+ * Copyright (C) 2017-2022 Johannah Sprinz <hannah@ubports.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/common.spec.js
+++ b/src/common.spec.js
@@ -1,7 +1,8 @@
 "use strict";
 
 /*
- * Copyright (C) 2017-2021 UBports Foundation <info@ubports.com>
+ * Copyright (C) 2017-2022 UBports Foundation <info@ubports.com>
+ * Copyright (C) 2017-2022 Johannah Sprinz <hannah@ubports.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/fastboot.js
+++ b/src/fastboot.js
@@ -1,7 +1,8 @@
 "use strict";
 
 /*
- * Copyright (C) 2017-2020 UBports Foundation <info@ubports.com>
+ * Copyright (C) 2017-2022 UBports Foundation <info@ubports.com>
+ * Copyright (C) 2017-2022 Johannah Sprinz <hannah@ubports.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/fastboot.spec.js
+++ b/src/fastboot.spec.js
@@ -82,6 +82,7 @@ describe("Fastboot module", function () {
             on: jest.fn((_, cb) => {
               if (i++ === 0) {
                 cb("Sending 'boot'");
+                cb("OKAY");
                 setTimeout(() => cb("Writing 'boot'"), 1);
                 setTimeout(() => cb("Finished 'boot'"), 2);
               } else {
@@ -119,7 +120,7 @@ describe("Fastboot module", function () {
             expect(child_process.spawn).toHaveBeenCalledWith(
               fastboot.executable,
               ["flash", "boot", "/path/to/boot.img"],
-              { env: { ADB_TRACE: "rwx" } }
+              { env: expect.objectContaining({ ADB_TRACE: "rwx" }) }
             );
             expect(child_process.spawn).toHaveBeenCalledWith(
               fastboot.executable,
@@ -130,7 +131,7 @@ describe("Fastboot module", function () {
                 "--disable-verity",
                 "/path/to/recovery.img"
               ],
-              { env: { ADB_TRACE: "rwx" } }
+              { env: expect.objectContaining({ ADB_TRACE: "rwx" }) }
             );
             expect(progress).toHaveBeenCalledWith(0);
             expect(progress).toHaveBeenCalledWith(0.15);
@@ -180,7 +181,7 @@ describe("Fastboot module", function () {
               expect(child_process.spawn).toHaveBeenCalledWith(
                 fastboot.executable,
                 ["flash", "boot", "/path/to/image"],
-                { env: { ADB_TRACE: "rwx" } }
+                { env: expect.objectContaining({ ADB_TRACE: "rwx" }) }
               );
               done();
             });

--- a/src/fastboot.spec.js
+++ b/src/fastboot.spec.js
@@ -1,7 +1,8 @@
 "use strict";
 
 /*
- * Copyright (C) 2017-2021 UBports Foundation <info@ubports.com>
+ * Copyright (C) 2017-2022 UBports Foundation <info@ubports.com>
+ * Copyright (C) 2017-2022 Johannah Sprinz <hannah@ubports.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/heimdall.js
+++ b/src/heimdall.js
@@ -1,7 +1,8 @@
 "use strict";
 
 /*
- * Copyright (C) 2019-2020 UBports Foundation <info@ubports.com>
+ * Copyright (C) 2019-2022 UBports Foundation <info@ubports.com>
+ * Copyright (C) 2019-2022 Johannah Sprinz <hannah@ubports.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/heimdall.spec.js
+++ b/src/heimdall.spec.js
@@ -1,7 +1,8 @@
 "use strict";
 
 /*
- * Copyright (C) 2019-2021 UBports Foundation <info@ubports.com>
+ * Copyright (C) 2019-2022 UBports Foundation <info@ubports.com>
+ * Copyright (C) 2019-2022 Johannah Sprinz <hannah@ubports.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/module.js
+++ b/src/module.js
@@ -1,7 +1,8 @@
 "use strict";
 
 /*
- * Copyright (C) 2017-2020 UBports Foundation <info@ubports.com>
+ * Copyright (C) 2017-2022 UBports Foundation <info@ubports.com>
+ * Copyright (C) 2017-2022 Johannah Sprinz <hannah@ubports.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/module.spec.js
+++ b/src/module.spec.js
@@ -1,7 +1,8 @@
 "use strict";
 
 /*
- * Copyright (C) 2017-2021 UBports Foundation <info@ubports.com>
+ * Copyright (C) 2017-2022 UBports Foundation <info@ubports.com>
+ * Copyright (C) 2017-2022 Johannah Sprinz <hannah@ubports.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/tool.js
+++ b/src/tool.js
@@ -1,7 +1,8 @@
 "use strict";
 
 /*
- * Copyright (C) 2017-2020 UBports Foundation <info@ubports.com>
+ * Copyright (C) 2017-2022 UBports Foundation <info@ubports.com>
+ * Copyright (C) 2017-2022 Johannah Sprinz <hannah@ubports.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/tool.js
+++ b/src/tool.js
@@ -19,7 +19,7 @@
  */
 
 import child_process from "child_process";
-import { getAndroidToolPath } from "android-tools-bin";
+import { getAndroidToolPath, getAndroidToolBaseDir } from "android-tools-bin";
 import EventEmitter from "events";
 import { removeFalsy } from "./common.js";
 import { CancelablePromise } from "./cancelable-promise.js";
@@ -39,6 +39,12 @@ export class Tool extends EventEmitter {
     this.extra = options?.extra || [];
     this.execOptions = options?.execOptions || {};
     this.processes = [];
+    if (
+      options.setPath &&
+      process.env.PATH &&
+      !process.env.PATH.includes(getAndroidToolBaseDir())
+    )
+      process.env.PATH = `${getAndroidToolBaseDir()}:${process.env.PATH}`;
   }
 
   /**
@@ -117,6 +123,7 @@ export class Tool extends EventEmitter {
       [...this.extra, ...args].flat(),
       {
         env: {
+          ...process.env,
           ADB_TRACE: "rwx"
         }
       }

--- a/src/tool.spec.js
+++ b/src/tool.spec.js
@@ -1,7 +1,8 @@
 "use strict";
 
 /*
- * Copyright (C) 2019-2021 UBports Foundation <info@ubports.com>
+ * Copyright (C) 2019-2022 UBports Foundation <info@ubports.com>
+ * Copyright (C) 2019-2022 Johannah Sprinz <hannah@ubports.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/tool.spec.js
+++ b/src/tool.spec.js
@@ -41,7 +41,7 @@ describe("Tool module", function () {
   describe("constructor()", function () {
     ["adb", "fastboot", "heimdall"].forEach(t => {
       it(`should create generic ${t}`, function () {
-        const tool = new Tool({ tool: t });
+        const tool = new Tool({ tool: t, setPath: true });
         expect(tool).toExist;
         expect(tool.tool).toEqual(t);
         expect(tool.executable).toMatch(t);
@@ -218,7 +218,7 @@ describe("Tool module", function () {
             expect(child_process.spawn).toHaveBeenCalledWith(
               tool.executable,
               [...tool.extra, ...args],
-              { env: { ADB_TRACE: "rwx" } }
+              { env: expect.objectContaining({ ADB_TRACE: "rwx" }) }
             );
             expect(spawnStartListenerStub).toHaveBeenCalledWith({
               cmd: [tool.tool, ...tool.extra, ...args]


### PR DESCRIPTION
pass `{setPath: true}` when instantiating a tool to automatically add the bundled binaries to the PATH environment variable. This ensures the bundled binaries are used, rather than the system ones