### PR TITLE
Implement automatically pushing docs to gh-pages.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,3 +79,46 @@ jobs:
         with:
           file: coverage/lcov.info
           verbose: true
+
+  github-pages:
+    name: Publish Docs
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Use Node.js 16
+        uses: actions/setup-node@v1
+        with:
+          node-version: "16"
+      - name: Build docs
+        run: |
+          npm ci
+          npm run docs
+          cd docs/promise-android-tools/$(node -p "require('./package.json').version") 
+          tar czf ../../../pages.tgz .
+
+      - name: Upload docs
+        uses: actions/upload-artifact@v3
+        with:
+          name: pages
+          path: pages.tgz
+          retention-days: 1
+
+      - name: Change to pages branch
+        uses: actions/checkout@v3
+        with:
+          ref: gh-pages
+
+      - name: Download docs
+        uses: actions/download-artifact@v3
+        with:
+          name: pages
+
+      - name: Add new docs
+        run: |
+          tar xzf pages.tgz
+          git config --global user.name "${{ github.actor }}"
+          git config --global user.email "${{ github.actor }}@users.noreply.github.com"
+          git add $(tar tzf pages.tgz)
+          git commit -m 'New doc pages from GitHub Workflow'
+          git push origin gh-pages


### PR DESCRIPTION
Closes issue #75 

Ensure an empty branch is created which is labeled `gh-pages` or else the checkout for this by the action will fail.