### PR TITLE
.github: fix CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,1 @@
-* @amartinz
-* @Flohack74
-* @maciek134
+* @amartinz @Flohack74 @maciek134


### PR DESCRIPTION
All owners need to be in a single line, otherwise it will override the previous lines.

Fixes: 6b4deabf609628d568e0002b597ee3675834d009